### PR TITLE
feat: skeleton for free server tab

### DIFF
--- a/app/Http/Controllers/Api/Client/FreeServerController.php
+++ b/app/Http/Controllers/Api/Client/FreeServerController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Pterodactyl\Http\Controllers\Api\Client;
+
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Pterodactyl\Models\FreeServer;
+
+class FreeServerController extends ClientApiController
+{
+    public function index(Request $request)
+    {
+        $free = FreeServer::where('user_id', $request->user()->id)->first();
+
+        return $this->fractal->item($free)->transformWith(function (?FreeServer $server) {
+            if (!$server) {
+                return null;
+            }
+
+            return [
+                'id' => $server->id,
+                'expires_at' => $server->expires_at,
+            ];
+        })->respond();
+    }
+
+    public function claim(Request $request)
+    {
+        if (FreeServer::where('user_id', $request->user()->id)->exists()) {
+            return $this->respondWithError('Free server already claimed.');
+        }
+
+        // @todo Actually provision a server for the user.
+        $expires = Carbon::now()->addSeconds(config('free-servers.default_duration'));
+
+        $free = FreeServer::create([
+            'user_id' => $request->user()->id,
+            'expires_at' => $expires,
+        ]);
+
+        return $this->fractal->item($free)->transformWith(function (FreeServer $server) {
+            return [
+                'id' => $server->id,
+                'expires_at' => $server->expires_at,
+            ];
+        })->respond(201);
+    }
+
+    public function extend(Request $request)
+    {
+        $free = FreeServer::where('user_id', $request->user()->id)->firstOrFail();
+
+        $window = config('free-servers.extend_window');
+        if ($free->expires_at->copy()->subSeconds($window)->isFuture()) {
+            return $this->respondWithError('Extension window has not yet opened.');
+        }
+
+        $free->expires_at = $free->expires_at->copy()->addSeconds(config('free-servers.extend_duration'));
+        $free->save();
+
+        return $this->fractal->item($free)->transformWith(function (FreeServer $server) {
+            return [
+                'id' => $server->id,
+                'expires_at' => $server->expires_at,
+            ];
+        })->respond();
+    }
+}

--- a/app/Models/FreeServer.php
+++ b/app/Models/FreeServer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Pterodactyl\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Carbon\Carbon;
+
+class FreeServer extends Model
+{
+    protected $table = 'free_servers';
+
+    protected $fillable = [
+        'user_id',
+        'server_id',
+        'expires_at',
+    ];
+
+    protected $dates = [
+        'expires_at',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function server(): BelongsTo
+    {
+        return $this->belongsTo(Server::class);
+    }
+}

--- a/config/free-servers.php
+++ b/config/free-servers.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    // Default duration in seconds a free server is active after being claimed.
+    'default_duration' => env('FREE_SERVER_DURATION', 3 * 60 * 60),
+    // How many seconds to extend the server when the user requests an extension.
+    'extend_duration' => env('FREE_SERVER_EXTEND', 3 * 60 * 60),
+    // How many seconds before expiration the user is allowed to extend.
+    'extend_window' => env('FREE_SERVER_EXTEND_WINDOW', 30 * 60),
+];

--- a/database/migrations/2024_01_01_000000_create_free_servers_table.php
+++ b/database/migrations/2024_01_01_000000_create_free_servers_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('free_servers', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('server_id')->nullable();
+            $table->timestamp('expires_at');
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->foreign('server_id')->references('id')->on('servers')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('free_servers');
+    }
+};

--- a/resources/scripts/components/NavigationBar.tsx
+++ b/resources/scripts/components/NavigationBar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCogs, faLayerGroup, faSignOutAlt } from '@fortawesome/free-solid-svg-icons';
+import { faCogs, faLayerGroup, faSignOutAlt, faGift } from '@fortawesome/free-solid-svg-icons';
 import { useStoreState } from 'easy-peasy';
 import { ApplicationStore } from '@/state';
 import SearchContainer from '@/components/dashboard/search/SearchContainer';
@@ -64,6 +64,11 @@ export default () => {
                     <Tooltip placement={'bottom'} content={'Dashboard'}>
                         <NavLink to={'/'} exact>
                             <FontAwesomeIcon icon={faLayerGroup} />
+                        </NavLink>
+                    </Tooltip>
+                    <Tooltip placement={'bottom'} content={'Free Servers'}>
+                        <NavLink to={'/free'}>
+                            <FontAwesomeIcon icon={faGift} />
                         </NavLink>
                     </Tooltip>
                     {rootAdmin && (

--- a/resources/scripts/components/free/FreeServerContainer.tsx
+++ b/resources/scripts/components/free/FreeServerContainer.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import PageContentBlock from '@/components/elements/PageContentBlock';
+
+const FreeServerContainer = () => {
+    return (
+        <PageContentBlock title={'Free Server'}>
+            <p>Free server management coming soon.</p>
+        </PageContentBlock>
+    );
+};
+
+export default FreeServerContainer;

--- a/resources/scripts/routers/DashboardRouter.tsx
+++ b/resources/scripts/routers/DashboardRouter.tsx
@@ -8,6 +8,7 @@ import SubNavigation from '@/components/elements/SubNavigation';
 import { useLocation } from 'react-router';
 import Spinner from '@/components/elements/Spinner';
 import routes from '@/routers/routes';
+import FreeServerContainer from '@/components/free/FreeServerContainer';
 
 export default () => {
     const location = useLocation();
@@ -33,6 +34,9 @@ export default () => {
                     <Switch location={location}>
                         <Route path={'/'} exact>
                             <DashboardContainer />
+                        </Route>
+                        <Route path={'/free'} exact>
+                            <FreeServerContainer />
                         </Route>
                         {routes.account.map(({ path, component: Component }) => (
                             <Route key={path} path={`/account/${path}`.replace('//', '/')} exact>

--- a/routes/api-client.php
+++ b/routes/api-client.php
@@ -19,6 +19,12 @@ use Pterodactyl\Http\Middleware\Api\Client\Server\AuthenticateServerAccess;
 Route::get('/', [Client\ClientController::class, 'index'])->name('api:client.index');
 Route::get('/permissions', [Client\ClientController::class, 'permissions']);
 
+Route::prefix('/free-server')->group(function () {
+    Route::get('/', [Client\FreeServerController::class, 'index']);
+    Route::post('/', [Client\FreeServerController::class, 'claim']);
+    Route::post('/extend', [Client\FreeServerController::class, 'extend']);
+});
+
 Route::prefix('/account')->middleware(AccountSubject::class)->group(function () {
     Route::prefix('/')->withoutMiddleware(RequireTwoFactorAuthentication::class)->group(function () {
         Route::get('/', [Client\AccountController::class, 'index'])->name('api:client.account');


### PR DESCRIPTION
## Summary
- add configuration and database table for tracking temporary free servers
- expose API endpoints and navigation link for basic free server page

## Testing
- `composer install` *(fails: requires ext-sodium)*
- `phpunit` *(command not found)*
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_689b9b5aa8648324b382644ceb85663f